### PR TITLE
fix: allow AvailableStock to be "0"

### DIFF
--- a/src/RequestHandler/StockRequestHandler.php
+++ b/src/RequestHandler/StockRequestHandler.php
@@ -46,7 +46,7 @@ class StockRequestHandler extends RequestHandlerBase
             return Response::badRequest('Es wurde keine ProductId übergeben');
         }
 
-        if (!isset($data['AvailableStock']) || empty($availableStock = (float)trim($data['AvailableStock']))) {
+        if (!isset($data['AvailableStock']) || ($data['AvailableStock'] !== "0" && empty($availableStock = (float)trim($data['AvailableStock'])))) {
             return Response::badRequest('Es wurde kein AvailableStock übergeben');
         };
 

--- a/src/RequestHandler/StockRequestHandler.php
+++ b/src/RequestHandler/StockRequestHandler.php
@@ -46,7 +46,7 @@ class StockRequestHandler extends RequestHandlerBase
             return Response::badRequest('Es wurde keine ProductId übergeben');
         }
 
-        if (!isset($data['AvailableStock']) || ($data['AvailableStock'] !== "0" && empty($availableStock = (float)trim($data['AvailableStock'])))) {
+        if (!isset($data['AvailableStock']) || (empty($availableStock = (float)trim($data['AvailableStock'])) && $data['AvailableStock'] !== "0")) {
             return Response::badRequest('Es wurde kein AvailableStock übergeben');
         };
 


### PR DESCRIPTION
Billbee sends this value legitly. In case a product was sold out in another store or the stock was deleted, this needs to be reflected in all stores to prevent new orders for that product